### PR TITLE
Fix road visibility by accounting for world scale

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -469,8 +469,9 @@ const App: React.FC = () => {
         if (!segmentsContainerRef.current) return;
         segmentsContainerRef.current.removeChildren();
         const graphics = new PIXI.Graphics();
+        const scale = worldRef.current?.scale.x ?? 1;
         for (const seg of segments) {
-            graphics.lineStyle(seg.width, seg.q.highway ? 0xd3d3d3 : 0x666666);
+            graphics.lineStyle(seg.width / scale, seg.q.highway ? 0xd3d3d3 : 0x666666);
             graphics.moveTo(seg.r.start.x, seg.r.start.y);
             graphics.lineTo(seg.r.end.x, seg.r.end.y);
         }


### PR DESCRIPTION
## Summary
- ensure road line widths compensate for the world container's scale, making streets and highways visible

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c022a83de0832abcb49cce7e5e0885